### PR TITLE
Jts page nav

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,12 +11,12 @@
             "elm/html": "1.0.0",
             "elm/random": "1.0.0",
             "elm/svg": "1.0.1",
+            "elm/url": "1.0.0",
             "tesk9/palette": "2.0.0"
         },
         "indirect": {
             "elm/json": "1.1.2",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"
         }
     },

--- a/src/Dots.elm
+++ b/src/Dots.elm
@@ -1,0 +1,285 @@
+module Dots exposing (Model, Msg, init, update, view)
+
+import Browser
+import Browser.Dom exposing (Viewport, getViewport)
+import Color
+import Html exposing (Html, button, div, p, text)
+import Html.Attributes exposing (class)
+import Html.Events exposing (onClick)
+import Random
+import Session exposing (WithSession)
+import Svg exposing (circle, rect, svg)
+import Svg.Attributes exposing (cx, cy, fill, height, r, rx, ry, viewBox, width, x, y)
+import Svg.Events
+import Task
+
+
+type alias Model =
+    WithSession
+        { viewport : Maybe Viewport
+        , colNumber : Int
+        , baseColor : DotColor
+        , origin : Coordinate
+        }
+
+
+type alias Coordinate =
+    ( Row, Col )
+
+
+type alias Row =
+    Int
+
+
+type alias Col =
+    Int
+
+
+showCoordinate : Coordinate -> String
+showCoordinate coordinate =
+    "(" ++ (String.fromInt <| Tuple.first coordinate) ++ "," ++ (String.fromInt <| Tuple.second coordinate) ++ ")"
+
+
+type PrimaryColor
+    = Red
+    | Green
+    | Blue
+
+
+type alias DotColor =
+    { red : Int
+    , green : Int
+    , blue : Int
+    }
+
+
+showDotColor : DotColor -> String
+showDotColor { red, green, blue } =
+    "Red: "
+        ++ String.fromInt red
+        ++ " Green: "
+        ++ String.fromInt green
+        ++ " Blue: "
+        ++ String.fromInt blue
+
+
+type Msg
+    = GotViewport Viewport
+    | IncrementColNumber
+    | DecrementColNumber
+    | ClickDot DotColor Coordinate
+    | RandomizeColor Int
+    | GetRandomColor
+
+
+init : Session.Model -> ( Model, Cmd Msg )
+init session =
+    ( { session = session
+      , viewport = Nothing
+      , colNumber = 6
+      , baseColor = { red = 12, green = 12, blue = 12 }
+      , origin = ( 7, 3 )
+      }
+    , Task.perform GotViewport getViewport
+    )
+
+
+generateBaseColor : Cmd Msg
+generateBaseColor =
+    Random.generate RandomizeColor <| Random.int 1 12
+
+
+view : Model -> Html Msg
+view model =
+    let
+        buttonStyle =
+            "mr-4 bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
+    in
+    case model.viewport of
+        Just viewport ->
+            div [ class "p-32" ]
+                [ div []
+                    [ button [ class buttonStyle, onClick IncrementColNumber ] [ text "+" ]
+                    , button [ class buttonStyle, onClick DecrementColNumber ] [ text "-" ]
+                    , button [ class buttonStyle, onClick GetRandomColor ] [ text "R" ]
+                    ]
+                , div [] [ text <| showDotColor model.baseColor ]
+                , div [] [ text <| showCoordinate model.origin ]
+                , art viewport model.colNumber model.baseColor model.origin
+                ]
+
+        Nothing ->
+            div [] [ text "loading..." ]
+
+
+art : Viewport -> Int -> DotColor -> Coordinate -> Html Msg
+art viewport colNumber baseColor origin =
+    let
+        { width, height } =
+            viewport.viewport
+
+        m =
+            min width height
+
+        w =
+            ceiling <| (m + 100) / toFloat (colNumber * 2)
+    in
+    div [ class "grid dot-box m-auto border-2" ] (listOfDots baseColor w colNumber origin)
+
+
+listOfDots : DotColor -> Int -> Int -> Coordinate -> List (Html Msg)
+listOfDots baseColor w count origin =
+    let
+        baseMatrix =
+            List.repeat count (List.repeat count 0)
+    in
+    List.indexedMap (\rowIdx row -> rowToDots baseColor w rowIdx row origin) baseMatrix
+
+
+rowToDots : DotColor -> Int -> Int -> List a -> Coordinate -> Html Msg
+rowToDots baseColor w rowIdx row origin =
+    div [ class "flex flex-row" ]
+        (List.indexedMap (\colIdx _ -> dot baseColor w rowIdx colIdx origin) row)
+
+
+getRed : Int -> Float
+getRed dist =
+    255 * sin (0.1 * toFloat dist)
+
+
+getGreen : Int -> Float
+getGreen dist =
+    255 * sin (0.2 * toFloat dist)
+
+
+getBlue : Int -> Float
+getBlue dist =
+    255 * sin (0.3 * toFloat dist)
+
+
+dot : DotColor -> Int -> Int -> Int -> Coordinate -> Html Msg
+dot { red, green, blue } w rowIdx colIdx origin =
+    let
+        distanceToRow =
+            rowIdx - Tuple.first origin
+
+        distanceToCol =
+            colIdx - Tuple.second origin
+
+        nextRed =
+            getRed distanceToRow
+
+        nextGreen =
+            getGreen distanceToRow
+
+        nextBlue =
+            getBlue distanceToRow
+
+        dotColor =
+            DotColor red green blue
+
+        fillColor =
+            Color.fromRGB ( nextRed, nextGreen, nextBlue )
+                |> Color.toRGBString
+
+        wString =
+            String.fromInt w
+
+        rString =
+            String.fromInt (w // 2)
+    in
+    div [ class "w-full h-full flex justify-center items-center" ]
+        [ svg [ Svg.Events.onClick <| ClickDot dotColor ( rowIdx, colIdx ), width wString, height wString, viewBox ("0 0 " ++ wString ++ " " ++ wString) ]
+            [ circle
+                [ cx rString
+                , cy rString
+                , fill fillColor
+                , r rString
+                , width <| String.fromInt w
+                , height <| String.fromInt w
+                ]
+                []
+            ]
+        ]
+
+
+square : Html msg
+square =
+    svg
+        [ width "400"
+        , height "400"
+        , viewBox "0 0 400 400"
+        ]
+        [ rect
+            [ x "10"
+            , y "10"
+            , fill "blue"
+            , width "100"
+            , height "100"
+            , rx "2"
+            , ry "2"
+            ]
+            []
+        ]
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        GotViewport viewport ->
+            ( { model | viewport = Just viewport }, Cmd.none )
+
+        IncrementColNumber ->
+            ( { model | colNumber = model.colNumber + 1 }, Cmd.none )
+
+        DecrementColNumber ->
+            ( { model | colNumber = model.colNumber - 1 }, Cmd.none )
+
+        ClickDot oldColor origin ->
+            let
+                nextColor =
+                    getNextColor oldColor
+            in
+            ( { model | baseColor = nextColor, origin = origin }, Cmd.none )
+
+        RandomizeColor color ->
+            let
+                nextColor =
+                    DotColor color 12 12
+            in
+            ( { model | baseColor = nextColor }, Cmd.none )
+
+        GetRandomColor ->
+            ( model, generateBaseColor )
+
+
+getNextColor : DotColor -> DotColor
+getNextColor color =
+    let
+        maxColor =
+            if Debug.log "red" color.red > color.green && color.green > color.blue then
+                Red
+
+            else if Debug.log "green" color.green > color.red && color.red > color.blue then
+                Green
+
+            else if Debug.log "blue" color.blue > color.red && color.red > color.green then
+                Blue
+
+            else
+                Red
+    in
+    case maxColor of
+        Red ->
+            { color | red = modColor <| color.red + 10, green = modColor <| color.green - 1, blue = modColor <| color.blue - 1 }
+
+        Green ->
+            { color | red = modColor <| color.red - 1, green = modColor <| color.green + 10, blue = modColor <| color.blue - 1 }
+
+        Blue ->
+            { color | red = modColor <| color.red - 1, green = modColor <| color.green - 1, blue = modColor <| color.blue + 10 }
+
+
+modColor : Int -> Int
+modColor c =
+    modBy 12 c

--- a/src/Dots.elm
+++ b/src/Dots.elm
@@ -203,26 +203,6 @@ dot { red, green, blue } w rowIdx colIdx origin =
         ]
 
 
-square : Html msg
-square =
-    svg
-        [ width "400"
-        , height "400"
-        , viewBox "0 0 400 400"
-        ]
-        [ rect
-            [ x "10"
-            , y "10"
-            , fill "blue"
-            , width "100"
-            , height "100"
-            , rx "2"
-            , ry "2"
-            ]
-            []
-        ]
-
-
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of

--- a/src/Home.elm
+++ b/src/Home.elm
@@ -1,0 +1,37 @@
+module Home exposing (Model, Msg, init, subscriptions, update, view)
+
+import Html exposing (Html, a, div, text)
+import Route
+import Session exposing (WithSession)
+
+
+type alias Model =
+    WithSession {}
+
+
+type Msg
+    = NoOp
+
+
+init : Session.Model -> ( Model, Cmd Msg )
+init session =
+    ( { session = session }, Cmd.none )
+
+
+view : Model -> Html msg
+view model =
+    div []
+        [ a [ Route.href Route.Dots ] [ text "Dots" ]
+        ]
+
+
+update : Model -> Msg -> ( Model, Cmd Msg )
+update model msg =
+    case msg of
+        NoOp ->
+            ( model, Cmd.none )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions =
+    always Sub.none

--- a/src/Home.elm
+++ b/src/Home.elm
@@ -1,6 +1,7 @@
 module Home exposing (Model, Msg, init, subscriptions, update, view)
 
 import Html exposing (Html, a, div, text)
+import Html.Attributes exposing (class)
 import Route
 import Session exposing (WithSession)
 
@@ -20,8 +21,9 @@ init session =
 
 view : Model -> Html msg
 view model =
-    div []
+    div [ class "flex flex-col" ]
         [ a [ Route.href Route.Dots ] [ text "Dots" ]
+        , a [ Route.href Route.Squares ] [ text "Squares" ]
         ]
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,279 +2,206 @@ module Main exposing (..)
 
 import Browser
 import Browser.Dom exposing (Viewport, getViewport)
+import Browser.Navigation as Nav
 import Color
-import Html exposing (Html, button, div, p, text)
+import Dots
+import Home
+import Html exposing (Html, a, button, div, footer, h1, h2, p, text, ul)
 import Html.Attributes exposing (class)
 import Html.Events exposing (onClick)
 import Random
+import Route
+import Session
 import Svg exposing (circle, rect, svg)
 import Svg.Attributes exposing (cx, cy, fill, height, r, rx, ry, viewBox, width, x, y)
 import Svg.Events
 import Task
+import Url
 
 
-main : Program () Model Msg
+main : Program Flags Model Msg
 main =
-    Browser.element
-        { init = init
-        , view = view
+    Browser.application
+        { view = view
+        , init = init
         , update = update
-        , subscriptions = \_ -> Sub.none
+        , subscriptions = subscriptions
+        , onUrlChange = ChangedUrl
+        , onUrlRequest = ClickedLink
         }
 
 
-type alias Model =
-    { viewport : Maybe Viewport
-    , colNumber : Int
-    , baseColor : DotColor
-    , origin : Coordinate
-    }
-
-type alias Coordinate = (Row, Col)
-
-type alias Row = Int
-
-type alias Col = Int
-
-showCoordinate : Coordinate -> String
-showCoordinate coordinate =
-  "(" ++ (String.fromInt <| Tuple.first coordinate) ++ "," ++ (String.fromInt <| Tuple.second coordinate) ++ ")"
-
-type PrimaryColor
-    = Red
-    | Green
-    | Blue
+type alias Flags =
+    ()
 
 
-type alias DotColor =
-    { red : Int
-    , green : Int
-    , blue : Int
-    }
+
+---- MODEL ----
 
 
-showDotColor : DotColor -> String
-showDotColor { red, green, blue } =
-    "Red: "
-        ++ String.fromInt red
-        ++ " Green: "
-        ++ String.fromInt green
-        ++ " Blue: "
-        ++ String.fromInt blue
+type Model
+    = NotFound Session.Model
+    | Loading Session.Model
+    | Home Home.Model
+    | Dots Dots.Model
+
+
+init : Flags -> Url.Url -> Nav.Key -> ( Model, Cmd Msg )
+init _ url key =
+    let
+        session =
+            Session.initial key
+    in
+    changeRouteTo (Route.fromUrl url)
+        (Loading session)
+
+
+
+---- UPDATE ----
 
 
 type Msg
-    = GotViewport Viewport
-    | IncrementColNumber
-    | DecrementColNumber
-    | ClickDot DotColor Coordinate
-    | RandomizeColor Int
-    | GetRandomColor
-
-
-init : () -> ( Model, Cmd Msg )
-init flags =
-    ( { viewport = Nothing
-      , colNumber = 6
-      , baseColor = { red = 12, green = 12, blue = 12}
-      , origin = (7, 3)
-      }
-    , Task.perform GotViewport getViewport
-    )
-
-
-generateBaseColor : Cmd Msg
-generateBaseColor =
-    Random.generate RandomizeColor <| Random.int 1 12
-
-
-view : Model -> Html Msg
-view model =
-    let
-        buttonStyle =
-            "mr-4 bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
-    in
-    case model.viewport of
-        Just viewport ->
-            div [ class "p-32" ]
-                [ div []
-                    [ button [ class buttonStyle, onClick IncrementColNumber ] [ text "+" ]
-                    , button [ class buttonStyle, onClick DecrementColNumber ] [ text "-" ]
-                    , button [ class buttonStyle, onClick GetRandomColor ] [ text "R" ]
-                    ]
-                , div [] [ text <| showDotColor model.baseColor ]
-                , div [] [ text <| showCoordinate model.origin]
-                , art viewport model.colNumber model.baseColor model.origin
-                ]
-
-        Nothing ->
-            div [] [ text "loading..." ]
-
-
-art : Viewport -> Int -> DotColor -> Coordinate -> Html Msg
-art viewport colNumber baseColor origin =
-    let
-        { width, height } =
-            viewport.viewport
-
-        m =
-            min width height
-
-        w =
-            ceiling <| (m + 100) / toFloat (colNumber * 2)
-    in
-    div [ class "grid dot-box m-auto border-2" ] (listOfDots baseColor w colNumber origin)
-
-
-listOfDots : DotColor -> Int -> Int -> Coordinate -> List (Html Msg)
-listOfDots baseColor w count origin =
-    let
-        baseMatrix =
-            List.repeat count (List.repeat count 0)
-    in
-    List.indexedMap (\rowIdx row -> rowToDots baseColor w rowIdx row origin) baseMatrix
-
-
-rowToDots : DotColor -> Int -> Int -> List a -> Coordinate -> Html Msg
-rowToDots baseColor w rowIdx row origin =
-    div [ class "flex flex-row" ]
-        (List.indexedMap (\colIdx _ -> dot baseColor w rowIdx colIdx origin) row)
-
-
-getRed : Int -> Float
-getRed dist =
-  255 * (sin (0.1 * (toFloat dist)))
-
-getGreen : Int -> Float
-getGreen dist =
-  255 * (sin (0.2 * (toFloat dist)))
-
-getBlue : Int -> Float
-getBlue dist =
-  255 * (sin (0.3 * (toFloat dist)))
-
-
-dot : DotColor -> Int -> Int -> Int -> Coordinate -> Html Msg
-dot { red, green, blue } w rowIdx colIdx origin =
-    let
-        distanceToRow = rowIdx - (Tuple.first origin)
-        distanceToCol = colIdx - (Tuple.second origin)
-
-        nextRed =
-           getRed distanceToRow
-
-        nextGreen =
-            getGreen distanceToRow
-
-        nextBlue =
-            getBlue distanceToRow
-
-        dotColor =
-            DotColor red green blue
-
-        fillColor =
-            Color.fromRGB ( nextRed, nextGreen, nextBlue )
-                |> Color.toRGBString
-
-        wString =
-            String.fromInt w
-
-        rString =
-            String.fromInt (w // 2)
-    in
-    div [ class "w-full h-full flex justify-center items-center" ]
-        [ svg [ Svg.Events.onClick <| ClickDot dotColor (rowIdx, colIdx), width wString, height wString, viewBox ("0 0 " ++ wString ++ " " ++ wString) ]
-            [ circle
-                [ cx rString
-                , cy rString
-                , fill fillColor
-                , r rString
-                , width <| String.fromInt w
-                , height <| String.fromInt w
-                ]
-                []
-            ]
-        ]
-
-
-square : Html msg
-square =
-    svg
-        [ width "400"
-        , height "400"
-        , viewBox "0 0 400 400"
-        ]
-        [ rect
-            [ x "10"
-            , y "10"
-            , fill "blue"
-            , width "100"
-            , height "100"
-            , rx "2"
-            , ry "2"
-            ]
-            []
-        ]
+    = ChangedUrl Url.Url
+    | ClickedLink Browser.UrlRequest
+    | GotViewport Viewport
+    | HandleHomeMsg Home.Msg
+    | HandleDotsMsg Dots.Msg
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-    case msg of
-        GotViewport viewport ->
-            ( { model | viewport = Just viewport }, Cmd.none )
+    case ( msg, model ) of
+        ( ClickedLink urlRequest, _ ) ->
+            case urlRequest of
+                Browser.Internal url ->
+                    case url.fragment of
+                        Nothing ->
+                            ( model, Cmd.none )
 
-        IncrementColNumber ->
-            ( { model | colNumber = model.colNumber + 1 }, Cmd.none )
+                        Just _ ->
+                            ( model
+                            , Nav.pushUrl (Session.navKey (toSession model)) (Url.toString url)
+                            )
 
-        DecrementColNumber ->
-            ( { model | colNumber = model.colNumber - 1 }, Cmd.none )
+                Browser.External href ->
+                    ( model
+                    , Nav.load href
+                    )
 
-        ClickDot oldColor origin ->
+        ( ChangedUrl url, _ ) ->
+            changeRouteTo (Route.fromUrl url) model
+
+        ( HandleHomeMsg subMsg, Home model_ ) ->
             let
-                nextColor =
-                    getNextColor oldColor
+                ( newModel, newMsg ) =
+                    Home.update model_ subMsg
             in
-            ( { model | baseColor = nextColor, origin = origin }, Cmd.none )
+            ( Home newModel
+            , Cmd.map HandleHomeMsg newMsg
+            )
 
-        RandomizeColor color ->
+        ( HandleDotsMsg subMsg, Dots model_ ) ->
             let
-                nextColor =
-                    DotColor color 12 12
+                ( newModel, newMsg ) =
+                    Dots.update subMsg model_
             in
-            ( { model | baseColor = nextColor }, Cmd.none )
+            ( Dots newModel
+            , Cmd.map HandleDotsMsg newMsg
+            )
 
-        GetRandomColor ->
-            ( model, generateBaseColor )
-        
+        ( _, _ ) ->
+            ( model, Cmd.none )
 
 
-getNextColor : DotColor -> DotColor
-getNextColor color =
+changeRouteTo : Maybe Route.Route -> Model -> ( Model, Cmd Msg )
+changeRouteTo maybeRoute model =
     let
-        maxColor =
-            if Debug.log "red" color.red > color.green && color.green > color.blue then
-                Red
-
-            else if Debug.log "green" color.green > color.red && color.red > color.blue then
-                Green
-
-            else if Debug.log "blue" color.blue > color.red && color.red > color.green then
-                Blue
-
-            else
-                Red
+        session =
+            toSession model
     in
-    case maxColor of
-        Red ->
-            { color | red = modColor <| color.red + 10, green = modColor <| color.green - 1, blue = modColor <| color.blue - 1 }
+    case maybeRoute of
+        Nothing ->
+            ( NotFound session, Cmd.none )
 
-        Green ->
-            { color | red = modColor <| color.red - 1, green = modColor <| color.green + 10, blue = modColor <| color.blue - 1 }
+        Just Route.Home ->
+            Home.init session
+                |> updateWith Home HandleHomeMsg
 
-        Blue ->
-            { color | red = modColor <| color.red - 1, green = modColor <| color.green - 1, blue = modColor <| color.blue + 10 }
+        Just Route.Dots ->
+            Dots.init session
+                |> updateWith Dots HandleDotsMsg
 
 
-modColor : Int -> Int
-modColor c =
-    modBy 12 c
+toSession : Model -> Session.Model
+toSession model =
+    case model of
+        NotFound v ->
+            v
+
+        Loading v ->
+            v
+
+        Home { session } ->
+            session
+
+        Dots { session } ->
+            session
+
+
+updateWith : (subModel -> Model) -> (subMsg -> Msg) -> ( subModel, Cmd subMsg ) -> ( Model, Cmd Msg )
+updateWith toModel toMsg ( subModel, subCmd ) =
+    ( toModel subModel
+    , Cmd.map toMsg subCmd
+    )
+
+
+
+---- SUBSCRIPTIONS ----
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    case model of
+        Home homeModel ->
+            Sub.map HandleHomeMsg <| Home.subscriptions homeModel
+
+        _ ->
+            Sub.none
+
+
+
+---- VIEW ----
+
+
+view : Model -> Browser.Document Msg
+view model =
+    { title = "Doodles"
+    , body =
+        [ h1 [] [ a [ Route.href Route.Home ] [ text "Doodles" ] ]
+        , pageContent model
+        , pageFooter
+        ]
+    }
+
+
+pageContent : Model -> Html Msg
+pageContent model =
+    case model of
+        Home homeModel ->
+            Html.map HandleHomeMsg <| Home.view homeModel
+
+        Dots dotsModel ->
+            Html.map HandleDotsMsg <| Dots.view dotsModel
+
+        NotFound _ ->
+            h2 [] [ text "Page not found" ]
+
+        Loading _ ->
+            text ""
+
+
+pageFooter : Html a
+pageFooter =
+    footer []
+        [ div [] [ text "" ]
+        ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -12,6 +12,7 @@ import Html.Events exposing (onClick)
 import Random
 import Route
 import Session
+import Squares
 import Svg exposing (circle, rect, svg)
 import Svg.Attributes exposing (cx, cy, fill, height, r, rx, ry, viewBox, width, x, y)
 import Svg.Events
@@ -44,6 +45,7 @@ type Model
     | Loading Session.Model
     | Home Home.Model
     | Dots Dots.Model
+    | Squares Squares.Model
 
 
 init : Flags -> Url.Url -> Nav.Key -> ( Model, Cmd Msg )
@@ -66,6 +68,7 @@ type Msg
     | GotViewport Viewport
     | HandleHomeMsg Home.Msg
     | HandleDotsMsg Dots.Msg
+    | HandleSquaresMsg Squares.Msg
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -109,6 +112,15 @@ update msg model =
             , Cmd.map HandleDotsMsg newMsg
             )
 
+        ( HandleSquaresMsg subMsg, Squares model_ ) ->
+            let
+                ( newModel, newMsg ) =
+                    Squares.update subMsg model_
+            in
+            ( Squares newModel
+            , Cmd.map HandleSquaresMsg newMsg
+            )
+
         ( _, _ ) ->
             ( model, Cmd.none )
 
@@ -131,6 +143,10 @@ changeRouteTo maybeRoute model =
             Dots.init session
                 |> updateWith Dots HandleDotsMsg
 
+        Just Route.Squares ->
+            Squares.init session
+                |> updateWith Squares HandleSquaresMsg
+
 
 toSession : Model -> Session.Model
 toSession model =
@@ -145,6 +161,9 @@ toSession model =
             session
 
         Dots { session } ->
+            session
+
+        Squares { session } ->
             session
 
 
@@ -187,11 +206,14 @@ view model =
 pageContent : Model -> Html Msg
 pageContent model =
     case model of
-        Home homeModel ->
-            Html.map HandleHomeMsg <| Home.view homeModel
+        Home m ->
+            Html.map HandleHomeMsg <| Home.view m
 
-        Dots dotsModel ->
-            Html.map HandleDotsMsg <| Dots.view dotsModel
+        Dots m ->
+            Html.map HandleDotsMsg <| Dots.view m
+
+        Squares m ->
+            Html.map HandleSquaresMsg <| Squares.view m
 
         NotFound _ ->
             h2 [] [ text "Page not found" ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,0 +1,55 @@
+module Route exposing
+    ( Route(..)
+    , fromUrl
+    , href
+    , replaceUrl
+    )
+
+import Browser.Navigation as Nav
+import Html exposing (Attribute)
+import Html.Attributes as Attr
+import Url exposing (Url)
+import Url.Parser as Parser exposing ((</>), Parser, oneOf, s)
+
+
+type Route
+    = Home
+    | Dots
+
+
+parser : Parser (Route -> a) a
+parser =
+    oneOf
+        [ Parser.map Home Parser.top
+        , Parser.map Dots (s "doodles" </> s "dots")
+        ]
+
+
+href : Route -> Attribute msg
+href targetRoute =
+    Attr.href (routeToString targetRoute)
+
+
+replaceUrl : Nav.Key -> Route -> Cmd msg
+replaceUrl key route =
+    Nav.replaceUrl key (routeToString route)
+
+
+fromUrl : Url -> Maybe Route
+fromUrl url =
+    { url | path = Maybe.withDefault "" url.fragment, fragment = Nothing }
+        |> Parser.parse parser
+
+
+routeToString : Route -> String
+routeToString page =
+    let
+        pieces =
+            case page of
+                Home ->
+                    []
+
+                Dots ->
+                    [ "doodles", "dots" ]
+    in
+    "#/" ++ String.join "/" pieces

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -15,6 +15,7 @@ import Url.Parser as Parser exposing ((</>), Parser, oneOf, s)
 type Route
     = Home
     | Dots
+    | Squares
 
 
 parser : Parser (Route -> a) a
@@ -22,6 +23,7 @@ parser =
     oneOf
         [ Parser.map Home Parser.top
         , Parser.map Dots (s "doodles" </> s "dots")
+        , Parser.map Squares (s "doodles" </> s "squares")
         ]
 
 
@@ -51,5 +53,8 @@ routeToString page =
 
                 Dots ->
                     [ "doodles", "dots" ]
+
+                Squares ->
+                    [ "doodles", "squares" ]
     in
     "#/" ++ String.join "/" pieces

--- a/src/Session.elm
+++ b/src/Session.elm
@@ -1,0 +1,28 @@
+module Session exposing
+    ( Model
+    , WithSession
+    , initial
+    , navKey
+    )
+
+import Browser.Navigation as Nav
+
+
+type alias WithSession a =
+    { a | session : Model }
+
+
+type alias Model =
+    { key : Nav.Key
+    }
+
+
+initial : Nav.Key -> Model
+initial key =
+    { key = key
+    }
+
+
+navKey : Model -> Nav.Key
+navKey { key } =
+    key

--- a/src/Squares.elm
+++ b/src/Squares.elm
@@ -1,0 +1,67 @@
+module Squares exposing (Model, Msg, init, update, view)
+
+import Browser.Dom exposing (Viewport, getViewport)
+import Html exposing (Html, div, text)
+import Session exposing (WithSession)
+import Svg exposing (rect, svg)
+import Svg.Attributes exposing (cx, cy, fill, height, r, rx, ry, viewBox, width, x, y)
+import Task
+
+
+type alias Model =
+    WithSession
+        { viewport : Maybe Viewport
+        }
+
+
+type Msg
+    = GotViewport Viewport
+
+
+init : Session.Model -> ( Model, Cmd Msg )
+init session =
+    ( { session = session
+      , viewport = Nothing
+      }
+    , Task.perform GotViewport getViewport
+    )
+
+
+
+---- UPDATE ----
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        GotViewport viewport ->
+            ( { model | viewport = Just viewport }, Cmd.none )
+
+
+
+---- VIEW ----
+
+
+view : Model -> Html Msg
+view model =
+    div [] [ square ]
+
+
+square : Html msg
+square =
+    svg
+        [ width "400"
+        , height "400"
+        , viewBox "0 0 400 400"
+        ]
+        [ rect
+            [ x "10"
+            , y "10"
+            , fill "blue"
+            , width "100"
+            , height "100"
+            , rx "2"
+            , ry "2"
+            ]
+            []
+        ]


### PR DESCRIPTION
Add boilerplate for spa navigation …
8332334
Why:
We would like to navigate between different urls to show different
doodles.

This commit:
Adds a fair amount of boilerplate to wire up all the required logic for
a spa with url based routing

---


Init squares page …
a052f67
This commit adds a starter for a squares piece.


---

### Gif

![doodles-spa](https://user-images.githubusercontent.com/16049495/76690085-3c483b80-6613-11ea-9086-918402be256f.gif)
